### PR TITLE
Add AutoML job support

### DIFF
--- a/src/automlapi/schemas/experiment.py
+++ b/src/automlapi/schemas/experiment.py
@@ -6,3 +6,7 @@ class Experiment(BaseModel):
     tenant_id: str
     task_type: str | None = None
     primary_metric: str | None = None
+    training_data: str | None = None
+    target_column_name: str | None = None
+    compute: str | None = None
+    n_cross_validations: int | None = None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+import datetime
 from app.services.automl import AzureAutoMLService
 
 @patch("app.services.automl.MLClient")
@@ -10,3 +11,32 @@ def test_list_datasets(mock_cred, mock_client):
     svc = AzureAutoMLService()
     datasets = svc.list_datasets()
     assert len(datasets) == 1
+
+
+@patch("app.services.automl.ClientSecretCredential")
+@patch("app.services.automl.MLClient")
+@patch("app.services.automl.automl.classification")
+def test_start_experiment(mock_classification, mock_client, mock_cred):
+    mock_job = object()
+    mock_classification.return_value = mock_job
+    mock_client.return_value.jobs.create_or_update.return_value = type(
+        "Job",
+        (),
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "name": "job1",
+            "creation_context": type("ctx", (), {"created_at": datetime.datetime.now()})(),
+        },
+    )()
+    svc = AzureAutoMLService()
+    from app.schemas.experiment import Experiment
+    exp = Experiment(
+        id="11111111-1111-1111-1111-111111111111",
+        tenant_id="t",
+        task_type="classification",
+        training_data="/data",
+        target_column_name="y",
+        compute="cpu",
+    )
+    run = svc.start_experiment(exp)
+    assert run.job_name == "job1"


### PR DESCRIPTION
## Summary
- extend `Experiment` schema with AutoML settings
- implement AutoML job creation using the Python SDK
- add unit test for starting an AutoML experiment

## Testing
- `AZURE_TENANT_ID=t AZURE_CLIENT_ID=c AZURE_CLIENT_SECRET=s AZURE_SUBSCRIPTION_ID=sub AZURE_ML_WORKSPACE=ws AZURE_ML_RESOURCE_GROUP=rg JWT_SECRET=j PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686546b951388330b5df983fa83996db