### PR TITLE
Use uv in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: |
-          pip install uv
-          uv pip install -r requirements.txt
+        run: uv sync --group dev
       - name: Run tests
-        run: |
-          uv pip install pytest
-          pytest
+        run: uv run pytest
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ To run the API you will need access to several Azure resources and some local to
 
 ## Quick start
 
-1. Install dependencies (Python 3.11) using [uv](https://github.com/astral-sh/uv):
+1. Install dependencies using [uv](https://github.com/astral-sh/uv):
 
    ```bash
-   uv pip install -r requirements.txt
+   uv sync
    ```
 
 2. Provide the required Azure and database settings as environment variables. At a minimum the following values are expected:
@@ -63,10 +63,10 @@ WebSocket endpoints are available for run status and endpoint traffic streaming.
 
 ## Testing
 
-Run unit tests with `pytest`:
+Run unit tests with `uv run pytest`:
 
 ```bash
-pytest
+uv run pytest
 ```
 
 ## Project status


### PR DESCRIPTION
## Summary
- switch to `astral-sh/setup-uv` for installing uv and Python
- install dependencies with `uv sync`
- run tests using `uv run pytest`
- update README test instructions

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865583880a88330920ef77c588344a8